### PR TITLE
docs: Fix plugin identifier for Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To use the plugin, just apply the plugin in your `build.gradle`:
 
 ```groovy
 plugins {
-    id 'nl.fabianm.kotlin.compiler.generated' version '1.0'
+    id 'nl.fabianm.kotlin.plugin.generated' version '1.0'
 }
 ```
 


### PR DESCRIPTION
This pull request fixes the incorrect Gradle plugin identifier in the README.

Fixes #2