### PR TITLE
API no longer supports LoadingOrder paramerter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To use the plugin, just apply the plugin in your `build.gradle`:
 
 ```groovy
 plugins {
-    id 'nl.fabianm.kotlin.plugin.generated' version '1.4.0'
+    id 'nl.fabianm.kotlin.plugin.generated' version '1.5.0'
 }
 ```
 
@@ -34,6 +34,7 @@ version you are using:
 |    1.2.*  |     1.0    |
 |    1.3.0+ |    1.3.3   |
 |    1.3.50+|    1.4.0   |
+|    1.3.61+|    1.5.0   |
 
 You can optionally configure the plugin as shown below:
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,14 +15,14 @@
  */
 
 plugins {
-    kotlin("jvm") version "1.3.50" apply false
+    kotlin("jvm") version "1.3.60" apply false
     id("org.jlleitschuh.gradle.ktlint") version "8.2.0" apply false
     id("com.github.johnrengelman.shadow") version "5.0.0" apply false
 }
 
 allprojects {
     group = "nl.fabianm.kotlin.plugin.generated"
-    version = "1.4.0"
+    version = "1.5.0"
 
     extra["junitJupiterVersion"] = "5.4.2"
     extra["junitPlatformVersion"] = "1.4.2"

--- a/plugin-compiler/src/main/kotlin/nl/fabianm/kotlin/plugin/generated/compiler/GeneratedPlugin.kt
+++ b/plugin-compiler/src/main/kotlin/nl/fabianm/kotlin/plugin/generated/compiler/GeneratedPlugin.kt
@@ -18,7 +18,6 @@ package nl.fabianm.kotlin.plugin.generated.compiler
 
 import com.intellij.mock.MockProject
 import com.intellij.openapi.extensions.Extensions
-import com.intellij.openapi.extensions.LoadingOrder
 import com.intellij.openapi.extensions.impl.ExtensionPointImpl
 import com.intellij.openapi.project.Project
 import nl.fabianm.kotlin.plugin.generated.compiler.GeneratedConfigurationKeys.ANNOTATION
@@ -109,5 +108,5 @@ fun <T> ProjectExtensionDescriptor<T>.registerExtensionAsFirst(project: Project,
     Extensions.getArea(project)
         .getExtensionPoint(extensionPointName)
         .let { it as ExtensionPointImpl }
-        .registerExtension(extension, LoadingOrder.LAST) {}
+        .registerExtension(extension, {})
 }

--- a/plugin-gradle/src/main/kotlin/nl/fabianm/kotlin/plugin/generated/gradle/GeneratedSubplugin.kt
+++ b/plugin-gradle/src/main/kotlin/nl/fabianm/kotlin/plugin/generated/gradle/GeneratedSubplugin.kt
@@ -50,7 +50,7 @@ class GeneratedKotlinGradleSubplugin : KotlinGradleSubplugin<AbstractCompile> {
     companion object {
         private const val GENERATED_ARTIFACT_NAME = "plugin-gradle"
         private const val GENERATED_GROUP_ID = "nl.fabianm.kotlin.plugin.generated"
-        private const val GENERATED_VERSION = "1.4.0"
+        private const val GENERATED_VERSION = "1.5.0"
         private const val GENERATED_COMPILER_PLUGIN_ID = "nl.fabianm.kotlin.plugin.generated"
         private val ANNOTATION_ARG_NAME = "annotation"
         private val VISIBLE_ARG_NAME = "visible"


### PR DESCRIPTION
Looks like the LoadingOrder parameter caused the break since the API for extensions no longer accepts it.

Also calling the `registerExtension` function without any args other than the extension is deprecated, so calling it with an empty Disposable so that hopefully it will survive any further API changes.

Passes the tests, and also tried with mavenLocal + another project I am working on and it seems to be working with kotlin 1.3.61